### PR TITLE
free resources of TCommonMsgClientHandler only once

### DIFF
--- a/DnMsgClient.pas
+++ b/DnMsgClient.pas
@@ -925,9 +925,9 @@ end;
 
 destructor TCommonMsgClientHandler.Destroy;
 begin
-  FDestroying := True;
   if FDestroying then
     exit;
+  FDestroying := True;
   //FreeAndNil(FStreamInfo);
   FreeAndNil(FClientList);
 {$IFNDEF USECONNECTFIBER}


### PR DESCRIPTION
In this case EurekaLog points to memory that allocated for FClientList. But if we open destructor we really can see that FClientList will never be emptied