### PR TITLE
enlarge MaxMessageSize

### DIFF
--- a/DnMsgClient.pas
+++ b/DnMsgClient.pas
@@ -8,8 +8,8 @@ uses JwaWinsock2, Classes, contnrs, SyncObjs, SysUtils,
 
 const
   ClientTempStorageSize = 8192;
-  //MaxMessageSize = 1024 * 1024 * 50; //50Mb
-  MaxMessageSize = 1024 * 50; //50Kb
+  MaxMessageSize = 1024 * 1024 * 50; //50Mb
+  //MaxMessageSize = 1024 * 50; //50Kb
 
 type
   TOnClientErrorEvent = procedure (Sender: TObject; ErrorMessage: AnsiString) of object;

--- a/DnMsgServer.pas
+++ b/DnMsgServer.pas
@@ -10,8 +10,8 @@ uses  Classes, SysUtils, SyncObjs, contnrs,
 
 const
   //The maximum message size expected by server
-  //MaxMessageSize = 128*1024*1024;
-  MaxMessageSize = 50*1024;
+  MaxMessageSize = 128*1024*1024;
+  //MaxMessageSize = 50*1024;
 
 type
   //enumeration for read stages


### PR DESCRIPTION
If we send message with size more then 60Kb then it will be dropped. To fix it we restore previous settings for message size
